### PR TITLE
Run Rails tests with GitHub Action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,29 @@
+name: Verify
+on: [pull_request]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup System
+        run: |
+          sudo apt-get install libsqlite3-dev
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup test database
+        env:
+          RAILS_ENV: test
+        run: |
+          bin/rails db:setup
+
+      - name: Run tests
+        run: |
+          bin/rails test

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get /home" do
+    get root_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Run Rails tests with GitHub Action
    
Configure a GitHub Action to run rails tests on every pull request.
    
Here's a rough guide, though ours is much simpler:
https://boringrails.com/articles/building-a-rails-ci-pipeline-with-github-actions/
    
Also, here's the GitHub Actions docs:
https://docs.github.com/en/actions/quickstart

----

Add a test for the homepage

This simple test asserts that the homepage (root URL) returns a success
status.

Not a terribly important test, but more importantly - having at least
one test in place allows us to start running unit tests regularly and as
part of CI, removing the friction to add more tests later.

----

Fixes #12 