### PR TITLE
add jquery-ujs to enable delete routes

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,4 +1,4 @@
 import "stylesheets/application.scss"
-import "jquery"
 import "@fortawesome/fontawesome-free/css/all"
+import 'jquery-ujs'
 import 'i18n-js/index.js.erb'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -4,8 +4,8 @@ const erb = require('./loaders/erb')
 const webpack = require('webpack')
 environment.plugins.prepend('Provide',
     new webpack.ProvidePlugin({
-        $: 'jquery/dist/jquery',
-        jQuery: 'jquery/dist/jquery',
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery',
         I18n: 'i18n-js/app/assets/javascripts/i18n'
     })
 )

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "autoprefixer": "^10.2.6",
     "i18n-js": "^3.8.0",
     "jquery": "^3.6.0",
+    "jquery-ujs": "^1.2.3",
     "postcss": "^8.3.0",
     "rails-erb-loader": "^5.5.2",
     "tailwindcss": "^2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4013,6 +4013,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery-ujs@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
+  integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
+
 jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"


### PR DESCRIPTION
kudos to @mkasberg for setting me on the right track with the comment about `rails.js` possibly being the issue with `DELETE` actions not working. After some reading up and some testing, I can confirm this is fixed by `yarn add`ing `jquery-ujs` and `import`ing in `application.js`. As simple as that!

Actually in order for this fix to work, I had to adjust how the webpack `ProviderPlugin` was making `jQuery` and `$` available. I had pointed them at the `dist` folder, whereas I should have been pointing them at the `src` folder. After that was done, `jQuery` and `$` became fully available throughout the application and `jquery-ujs` was able to pick up on them and initialize.

Fixes #26 .
Also fixes #41 .