### PR TITLE
enable hot module reloading

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,3 +26,6 @@
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy do |policy|
+  policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035' if Rails.env.development?
+end


### PR DESCRIPTION
As I'm reading the [webpacker README](https://github.com/rails/webpacker#development), I see it mentions that in **Rails 5.2+**,  
> you need to allow webpack-dev-server host as an allowed origin for `connect-src` if you are running your application in a restrict CSP environment (like Rails 5.2+). This can be done in Rails 5.2+ in the CSP initializer `config/initializers/content_security_policy.rb` with a snippet like _**[the one provided in this commit]**_