### PR TITLE
Fix users_controller POST test

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -16,8 +16,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create user" do
+    user_to_create = {
+      avatar: 'NewUserAvatar',
+      email: 'new_user@example.com',
+      password: 'new_user_password',
+      password_confirmation: 'new_user_password',
+      role: 'bride',
+      username: 'new_user'
+    }
+
     assert_difference('User.count') do
-      post users_url, params: { user: { avatar: @user.avatar, email: @user.email, password: @user.password_digest, role: @user.role, username: @user.username } }
+      post users_url, params: { user: user_to_create }
     end
 
     assert_redirected_to projects_url

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -43,7 +43,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update user" do
-    patch user_url(@user), params: { user: { avatar: @user.avatar, email: @user.email, password: @user.password_digest, role: @user.role, username: @user.username } }
+    patch user_url(@user), params: { user: { avatar: 'DifferentUserAvatar' } }
     assert_redirected_to projects_url
   end
 


### PR DESCRIPTION
To test `users_controller#create` (POST `/users`), we want to test
creating a new user. Since this user will be a new user, we should not
use a user that's already in our test fixtures - that user will already
exist.

Also, we need to pass `password_confirmation` with our params. Code on
the server will validate that `password` matches `password_confirmation`
before creating the new user, and will fail if they don't match or if
one is missing.

There was also a similar problem in the `users_controller#update` test, and
I fix that test here as well in the second commit.