### PR TITLE
Add Redis to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The project will now be cloned in a **marriage-booklet** subfolder of the **deve
 
 ## docker-compose
 
-We provide a docker-compose file that will start database and adminer services in Docker. The database will be created with a default username and password that match the development defaults in our app configuration so you don't need to edit anything. To use this, you need [Docker](https://www.docker.com/) installed. Follow the installation instructions on their website. Once Docker's installed, just run
+We provide a docker-compose file that will start database, redis, and adminer services in Docker. The database will be created with a default username and password that match the development defaults in our app configuration so you don't need to edit anything. To use this, you need [Docker](https://www.docker.com/) installed. Follow the installation instructions on their website. Once Docker's installed, just run
 
     docker-compose up
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,9 +23,9 @@ default: &default
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # Defaults to marriage_booklet.
-  username: <%= ENV['MARRIAGE_BOOKLET_DATABASE_USER'] || marriage_booklet %>
+  username: <%= ENV['MARRIAGE_BOOKLET_DATABASE_USER'] || 'marriage_booklet' %>
   # The password associated with the postgres role (username).
-  password: <%= ENV['MARRIAGE_BOOKLET_DATABASE_PASSWORD'] || password %>
+  password: <%= ENV['MARRIAGE_BOOKLET_DATABASE_PASSWORD'] || 'password' %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,14 @@ services:
       POSTGRES_DB: marriage_booklet_development
       POSTGRES_USER: ${MARRIAGE_BOOKLET_DATABASE_USER:-marriage_booklet}
       POSTGRES_PASSWORD: ${MARRIAGE_BOOKLET_DATABASE_PASSWORD:-password}
+
   adminer:
     image: adminer
     restart: always
     ports:
       - ${ADMINER_PORT:-8080}:8080
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
The project depends on redis, but redis was not present in `docker-compose.yml` Including it there is easy, and means that a single `docker-compose up` is sufficient to have a working development and test environment.

Also, I realized I introduced a bug in
https://github.com/opensourcecatholic/marriage-booklet/pull/110. I need to quote my `database.yml` since they're strings.